### PR TITLE
Change Typekit kit id

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -21,8 +21,8 @@
 	</script>
 	
     <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico" />
-    <script type="text/javascript" src="//use.typekit.net/bpm7cfb.js"></script>
-    <script type="text/javascript">try{Typekit.load();}catch(e){}</script>
+    <script src="https://use.typekit.net/xko1fbx.js"></script>
+    <script>try{Typekit.load({ async: true });}catch(e){}</script>
 	
   </head>
   <body>


### PR DESCRIPTION
Now, we have a dedicated kit for NYUSW.com separate from the one we use on the main tech@nyu site, which'll let us make that kit a bit lighter.